### PR TITLE
Removed an extra "o"

### DIFF
--- a/Call-for-Speakers.md
+++ b/Call-for-Speakers.md
@@ -53,7 +53,7 @@ responsibilities?
 - A Leadership Philosophy or Management Style
 - Motivation & Retention
 - Onboarding
-- One o on Ones
+- One on Ones
 - Postmortems, Retrospectives
 - Performance Reviews
 - Setting Team Goals


### PR DESCRIPTION
The suggested topic of `One on Ones` had an extra `o` in it. This commit just removes it so nobody else bugs you about the typo.